### PR TITLE
Fix misc. header button issues

### DIFF
--- a/src/manager/commands/pageHeaderManager.ts
+++ b/src/manager/commands/pageHeaderManager.ts
@@ -137,8 +137,10 @@ export default class PageHeaderManager extends CommandManagerBase {
 			// View already has buttons and we're not doing a full refresh
 			return;
 		}
-		for (const pair of this.pairs)
+		for (let i = this.pairs.length -1; i>=0; i--) {
+			const pair = this.pairs[i];
 			if (isModeActive(pair.mode)) this.addPageHeaderButton(leaf, pair);
+		}
 		if (this.plugin.settings.showAddCommand) this.addAdderButton(leaf);
 	}
 

--- a/src/manager/commands/pageHeaderManager.ts
+++ b/src/manager/commands/pageHeaderManager.ts
@@ -110,16 +110,12 @@ export default class PageHeaderManager extends CommandManagerBase {
 			// Remove all buttons on plugin unload
 			this.pairs.slice().forEach(pair => this.removeButtons(pair));
 		});
-		this.plugin.registerEvent(app.workspace.on("file-open", () => {
-			const activeLeaf = app.workspace.getMostRecentLeaf();
-			if (!activeLeaf) {
-				return;
-			}
-
-			this.addButtonsToLeaf(activeLeaf);
-			if (this.plugin.settings.showAddCommand) activeLeaf.containerEl.getElementsByClassName('view-actions')[0].prepend(this.addBtn);
+		this.plugin.registerEvent(app.workspace.on("layout-change", () => {
+			this.addButtonsToAllLeaves();
 		}));
-
+		this.plugin.registerEvent(app.workspace.on("active-leaf-change", activeLeaf => {
+			if (this.plugin.settings.showAddCommand) activeLeaf?.containerEl.getElementsByClassName('view-actions')[0].prepend(this.addBtn);
+		}));
 		this.plugin.register(() => this.addBtn.remove());
 		setIcon(this.addBtn, "plus");
 		this.addBtn.onmouseup = async (): Promise<void> => {
@@ -133,8 +129,6 @@ export default class PageHeaderManager extends CommandManagerBase {
 
 	private addButtonsToAllLeaves(): void {
 		app.workspace.iterateAllLeaves(leaf => this.addButtonsToLeaf(leaf));
-		//@ts-ignore
-		app.workspace.onLayoutChange();
 	}
 
 	private addButtonsToLeaf(leaf: WorkspaceLeaf): void {

--- a/src/manager/commands/pageHeaderManager.ts
+++ b/src/manager/commands/pageHeaderManager.ts
@@ -13,10 +13,7 @@ export default class PageHeaderManager extends CommandManagerBase {
 
 	public constructor(plugin: CommanderPlugin, pairArray: CommandIconPair[]) {
 		super(plugin, pairArray);
-		//@ts-ignore
-		if (app.vault.config.showViewHeader) {
-			this.init();
-		}
+		this.init();
 	}
 
 	private getButtonIcon(

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -191,6 +191,13 @@
 	&:hover {
 		opacity: 1;
 	}
+	// place adder button to the left of commander-added buttons
+	order: -1001;
+}
+
+.cmdr-page-header {
+	// place commander buttons to the left of view and Obsidian buttons
+	order: -1000;
 }
 
 .cmdr-macro-builder {

--- a/src/ui/components/settingTabComponent.tsx
+++ b/src/ui/components/settingTabComponent.tsx
@@ -73,19 +73,10 @@ export default function settingTabComponent({ plugin, mobileMode }: { plugin: Co
 				<ToggleComponent
 					value={plugin.settings.showAddCommand}
 					name={t("Show \"Add Command\" Button")}
-					description={t("Show the \"Add Command\" Button in every Menu. Requires restart.")}
+					description={t("Show the \"Add Command\" Button in every Menu.")}
 					changeHandler={async (value): Promise<void> => {
 						plugin.settings.showAddCommand = !value;
-
-						if (!plugin.settings.showAddCommand) {
-							const elements = document.getElementsByClassName("cmdr-adder");
-							for (let i = elements.length - 1; i >= 0; i--) {
-								elements.item(i)?.remove();
-							}
-						} else {
-							new Notice(t("Please restart Obsidian for these changes to take effect."));
-						}
-
+						plugin.manager.pageHeader.reorder();
 						await plugin.saveSettings();
 					}} />
 				<ToggleComponent


### PR DESCRIPTION
This PR addresses some issues with the page header buttons implementation:

- Memory leaks and cleanup/unload issues
- Not updating buttons when tab title bar turned on at runtime or shown by CSS
- Not removing buttons from all windows
- Janking title elements on active leaf change (see #25)
- Remove need to restart to turn on and off the adder button
- Buttons being displayed in reverse order from the order shown in settings, or being displayed after buttons supplied by Obsidian or a view's plugin

(And possibly other things - see commit messages for more details.  I tried to break everything into separate commits so it's clear what was changed at each step and why.  Also note that I didn't really review anything in the rest of the plugin, so I don't know how many of these issues might still apply elsewhere.)