### PR TITLE
fix: Correct repo link in issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         ## Self Check
-        - Try searching existing [GitHub Issues](https://github.com/phibr0/obsidian-dictionary/issues) (open or closed) for similar issues.
+        - Try searching existing [GitHub Issues](https://github.com/phibr0/obsidian-commander/issues) (open or closed) for similar issues.
   - type: textarea
     validations:
       required: true


### PR DESCRIPTION
While adding a new feature request, I saw that a link in the issue template points to the wrong plugin. So I fixed it. :)