### PR TITLE
fix page header button color

### DIFF
--- a/src/manager/commands/pageHeaderManager.ts
+++ b/src/manager/commands/pageHeaderManager.ts
@@ -33,10 +33,9 @@ export default class PageHeaderManager extends CommandManagerBase {
 		buttons.set(id, buttonIcon);
 
 		buttonIcon.addClasses(["cmdr-page-header", id]);
-		buttonIcon.style.color =
-			pair.color === "#000000" || pair.color === undefined
-				? "inherit"
-				: pair.color;
+		if (pair.color) {
+			buttonIcon.style.color = pair.color;
+		}
 		buttonIcon.addEventListener("contextmenu", (event) => {
 			event.stopImmediatePropagation();
 			new Menu()


### PR DESCRIPTION
Setting `color: inherit` on the page header buttons breaks the theming. See below screenshot.

I see other places where similar logic exists, but perhaps it is appropriate in some of those locations. I am only adding commands to the page header, so I haven't checked other locations.

![Screenshot_20240217-111952](https://github.com/phibr0/obsidian-commander/assets/253298/0f0f2ea0-6a72-4eff-bcbb-5dc7ac680b62)
