### PR TITLE
Add toggles to Commander

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SETTINGS: CommanderSettings = {
 	statusBar: [],
 	pageHeader: [],
 	macros: [],
+	toggles: [],
 	explorer: [],
 	hide: {
 		statusbar: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,23 @@ export default class CommanderPlugin extends Plugin {
 			)
 		);
 
+		this.registerDomEvent(document, 'fullscreenchange', () => {
+			if (document.fullscreenElement) {
+				this.settings.toggles.forEach((toggle, index) => {
+					if (toggle.triggerWhenEnteringFullscreen) {
+						this.executeToggle(index);
+					}
+				});
+			}
+			else {
+				this.settings.toggles.forEach((toggle, index) => {
+					if (toggle.triggerWhenExitingFullscreen) {
+						this.executeToggle(index);
+					}
+				});
+			}
+		});
+
 		app.workspace.onLayoutReady(() => {
 			updateHiderStylesheet(this.settings);
 			updateMacroCommands(this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {
 	injectIcons,
 	removeStyles,
 	updateMacroCommands,
+	updateToggleCommands,
 	updateStyles,
 } from "src/util";
 import { updateSpacing } from "src/util";
@@ -77,6 +78,15 @@ export default class CommanderPlugin extends Plugin {
 		}
 	}
 
+	public async executeToggle(id: number): Promise<void> {
+		const toggle = this.settings.toggles[id];
+		if (!toggle) throw new Error("Toggle not found");
+		toggle.nextCommandIndex = (toggle.nextCommandIndex + 1) % toggle.commands.length;
+		await this.saveSettings();
+		const commandId = toggle.commands[toggle.nextCommandIndex];
+		await app.commands.executeCommandById(commandId);
+	}
+
 	public async onload(): Promise<void> {
 		await this.loadSettings();
 		this.settings.hide.leftRibbon ??= []; // TODO: remove this in a future version
@@ -122,6 +132,7 @@ export default class CommanderPlugin extends Plugin {
 		app.workspace.onLayoutReady(() => {
 			updateHiderStylesheet(this.settings);
 			updateMacroCommands(this);
+			updateToggleCommands(this);
 			updateSpacing(this.settings.spacing);
 			updateStyles(this.settings.advancedToolbar);
 			injectIcons(this.settings.advancedToolbar);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {
 	PageHeaderManager,
 	StatusBarManager,
 } from "./manager/commands";
-import { Action, CommanderSettings } from "./types";
+import { Action, CommanderSettings, Toggle } from "./types";
 import CommanderSettingTab from "./ui/settingTab";
 import SettingTabModal from "./ui/settingTabModal";
 
@@ -144,6 +144,10 @@ export default class CommanderPlugin extends Plugin {
 	public onunload(): void {
 		document.head.querySelector("style#cmdr")?.remove();
 		removeStyles();
+		this.settings.toggles.forEach((toggle: Toggle) : void  => {
+			toggle.nextCommandIndex = 0;
+		});
+		this.saveSettings();
 	}
 
 	private async loadSettings(): Promise<void> {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -295,7 +295,7 @@
 	}
 
 	.cmdr-tab {
-		padding: 6px 8px;
+		padding: 6px 6px;
 		font-size: 14px;
 		font-weight: 600;
 		cursor: pointer;
@@ -304,7 +304,7 @@
 		border-right: 2px solid transparent;
 
 		&:first-child {
-			margin-left: 6px;
+			margin-left: 4px;
 		}
 
 		&.cmdr-tab-active {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface Toggle {
 	icon: string;
 	commands: string[];
 	nextCommandIndex: number;
+	triggerWhenEnteringFullscreen: boolean;
+	triggerWhenExitingFullscreen: boolean;
 }
 
 export interface CommanderSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,13 @@ export interface Macro {
 	macro: MacroItem[];
 }
 
+export interface Toggle {
+	name: string;
+	icon: string;
+	commands: string[];
+	nextCommandIndex: number;
+}
+
 export interface CommanderSettings {
 	confirmDeletion: boolean;
 	showAddCommand: boolean;
@@ -33,6 +40,7 @@ export interface CommanderSettings {
 	pageHeader: CommandIconPair[];
 	explorer: CommandIconPair[];
 	macros: Macro[];
+	toggles: Toggle[];
 	hide: {
 		statusbar: string[];
 		leftRibbon: string[];

--- a/src/ui/components/ToggleBuilder.tsx
+++ b/src/ui/components/ToggleBuilder.tsx
@@ -21,6 +21,8 @@ export default function ({
 	const [name, setName] = useState(toggle.name || "Toggle Name");
 	const [icon, setIcon] = useState(toggle.icon || "star");
 	const [nextCommandIndex] = useState(toggle.nextCommandIndex || 0);
+	const [triggerWhenExitingFullscreen, setTriggerWhenExitingFullscreen] = useState(toggle.triggerWhenExitingFullscreen || false);
+	const [triggerWhenEnteringFullscreen, setTriggerWhenEnteringFullscreen] = useState(toggle.triggerWhenEnteringFullscreen || false);
 	const [commands, setCommands] = useState<string[]>(
 		JSON.parse(JSON.stringify(toggle.commands)) || []
 	);
@@ -54,6 +56,22 @@ export default function ({
 					>
 						<ObsidianIcon icon={icon} />
 					</button>
+				</div>
+			</div>
+			<div class="setting-item">
+				<div>
+					<label><input 
+						type="checkbox" 
+						checked={triggerWhenEnteringFullscreen}
+						onChange={(e) : void => setTriggerWhenEnteringFullscreen(e.currentTarget.checked)}
+					/> Trigger when entering full screen</label>
+				</div>
+				<div>
+					<label><input 
+						type="checkbox" 
+						checked={triggerWhenExitingFullscreen}
+						onChange={(e) : void => setTriggerWhenExitingFullscreen(e.currentTarget.checked)}
+					/> Trigger when exiting full screen</label>
 				</div>
 			</div>
 
@@ -125,7 +143,7 @@ export default function ({
 					disabled={commands.length === 0}
 					onClick={() : void  => {
 						if (commands.length)
-							onSave({ commands: commands, name, icon, nextCommandIndex });
+							onSave({ commands: commands, name, icon, nextCommandIndex, triggerWhenEnteringFullscreen, triggerWhenExitingFullscreen });
 					}}
 				>
 					Save

--- a/src/ui/components/ToggleBuilder.tsx
+++ b/src/ui/components/ToggleBuilder.tsx
@@ -1,0 +1,137 @@
+import { h } from "preact";
+import { useState } from "preact/hooks";
+import CommanderPlugin from "src/main";
+import { Toggle } from "src/types";
+import { getCommandFromId, ObsidianIcon } from "src/util";
+import AddCommandModal from "../addCommandModal";
+import ChooseIconModal from "../chooseIconModal";
+
+interface ToggleBuilderProps {
+	plugin: CommanderPlugin;
+	toggle: Toggle;
+	onSave: (toggle: Toggle) => void;
+	onCancel: () => void;
+}
+export default function ({
+	plugin,
+	toggle,
+	onSave,
+	onCancel,
+}: ToggleBuilderProps): h.JSX.Element {
+	const [name, setName] = useState(toggle.name || "Toggle Name");
+	const [icon, setIcon] = useState(toggle.icon || "star");
+	const [nextCommandIndex] = useState(toggle.nextCommandIndex || 0);
+	const [commands, setCommands] = useState<string[]>(
+		JSON.parse(JSON.stringify(toggle.commands)) || []
+	);
+
+	const handleAddCommand = async () : Promise<void> => {
+		const command = await new AddCommandModal(plugin).awaitSelection();
+		if (command) {
+			setCommands([...commands, command.id]);
+		}
+	};
+
+	return (
+		<div>
+			<div class="setting-item cmdr-mm-item">
+				<div>
+					<span>Name</span>
+					<input
+						type="text"
+						placeholder="Toggle Name"
+						value={name}
+						onChange={(e) : void => setName(e.currentTarget.value)}
+						width="100%"
+					/>
+				</div>
+				<div>
+					<span>Icon</span>
+					<button
+						onClick={async () : Promise<void> =>
+							setIcon(await new ChooseIconModal(plugin).awaitSelection())
+						}
+					>
+						<ObsidianIcon icon={icon} />
+					</button>
+				</div>
+			</div>
+
+			{commands.map((item, idx) => {
+				const command = getCommandFromId(item);
+				return (
+					<div class="setting-item cmdr-mm-item">
+						<div>
+							<button
+								onClick={async (): Promise<void> => {
+									const newId = await new AddCommandModal(plugin).awaitSelection();
+									setCommands(commands.map((item, i) => (i === idx) ? newId.id : item));
+								}}
+							>
+								{command?.name || "Cannot find Command"}
+							</button>
+						</div>
+						<div>
+							<div class="cmdr-mm-action-options">
+								<ObsidianIcon
+									class="clickable-icon"
+									icon="arrow-down"
+									onClick={() : void => {
+										if (idx === commands.length - 1)
+											return;
+										const newCommands = [...commands];
+										const temp = newCommands[idx];
+										newCommands[idx] = newCommands[idx + 1];
+										newCommands[idx + 1] = temp;
+										setCommands(newCommands);
+									}}
+								/>
+								<ObsidianIcon
+									class="clickable-icon"
+									icon="arrow-up"
+									onClick={() : void => {
+										if (idx === 0) return;
+										const newCommands = [...commands];
+										const temp = newCommands[idx];
+										newCommands[idx] = newCommands[idx - 1];
+										newCommands[idx - 1] = temp;
+										setCommands(newCommands);
+									}}
+								/>
+								<ObsidianIcon
+									class="clickable-icon"
+									icon="cross"
+									onClick={() : void => {
+										setCommands(commands.filter((_, i) => i !== idx));
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+				);
+			})}
+
+			{commands.length < 2 && ( 
+				<div className="setting-item cmdr-mm-actions cmdr-justify-between">
+					<div>
+						<button onClick={handleAddCommand}>Add Command</button>
+					</div>
+				</div>
+			)}
+
+			<div className="cmdr-mm-control">
+				<button
+					class={commands.length === 0 ? "disabled" : "mod-cta"}
+					disabled={commands.length === 0}
+					onClick={() : void  => {
+						if (commands.length)
+							onSave({ commands: commands, name, icon, nextCommandIndex });
+					}}
+				>
+					Save
+				</button>
+				<button onClick={onCancel}>Cancel</button>
+			</div>
+		</div>
+	);
+}

--- a/src/ui/components/ToggleBuilderModal.ts
+++ b/src/ui/components/ToggleBuilderModal.ts
@@ -1,0 +1,39 @@
+import { Modal } from "obsidian";
+import { h, render } from "preact";
+import CommanderPlugin from "src/main";
+import { Toggle } from "src/types";
+import ToggleBuilderComponent from "./ToggleBuilder";
+
+export default class ToggleBuilderModal extends Modal {
+	private plugin: CommanderPlugin;
+	private toggle: Toggle;
+	private onSave: (toggle: Toggle) => void;
+
+	public constructor(
+		plugin: CommanderPlugin,
+		toggle: Toggle,
+		onSave: (toggle: Toggle) => void
+	) {
+		super(app);
+		this.toggle = toggle;
+		this.plugin = plugin;
+		this.onSave = onSave;
+	}
+
+	public onOpen(): void {
+		this.titleEl.setText("Toggle Builder");
+		render(
+			h(ToggleBuilderComponent, {
+				plugin: this.plugin,
+				toggle: this.toggle,
+				onSave: this.onSave,
+				onCancel: this.close.bind(this),
+			}),
+			this.contentEl
+		);
+	}
+
+	public onClose(): void {
+		render(null, this.contentEl);
+	}
+}

--- a/src/ui/components/ToggleViewer.tsx
+++ b/src/ui/components/ToggleViewer.tsx
@@ -91,7 +91,7 @@ export default function ToggleViewer({
 				<button
 					class="mod-cta"
 					onClick={() : void  =>
-						handleBuilder({ name: "", commands: [], nextCommandIndex: 0, icon: "star" })
+						handleBuilder({ name: "", icon: "star", commands: [], nextCommandIndex: 0, triggerWhenEnteringFullscreen: false, triggerWhenExitingFullscreen: false })
 					}
 				>
 					Add Toggle

--- a/src/ui/components/ToggleViewer.tsx
+++ b/src/ui/components/ToggleViewer.tsx
@@ -1,0 +1,102 @@
+import { Platform } from "obsidian";
+import { Fragment, h } from "preact";
+import t from "src/l10n";
+import CommanderPlugin from "src/main";
+import { Toggle } from "src/types";
+import { ObsidianIcon, updateToggleCommands } from "src/util";
+import ConfirmDeleteModal from "../confirmDeleteModal";
+import Logo from "./Logo";
+import ToggleBuilderModal from "./ToggleBuilderModal";
+
+interface ToggleBuilderProps {
+	plugin: CommanderPlugin;
+	toggles: Toggle[];
+}
+export default function ToggleViewer({
+	plugin,
+	toggles,
+}: ToggleBuilderProps): h.JSX.Element {
+	const handleBuilder = (toggle: Toggle, idx?: number) : void => {
+		const onClose = (updatedToggle: Toggle) : void => {
+			toggles.splice(
+				idx !== undefined ? idx : toggles.length,
+				idx !== undefined ? 1 : 0,
+				updatedToggle
+			);
+
+			plugin.saveSettings();
+			this.forceUpdate();
+			updateToggleCommands(plugin);
+			modal.close();
+		};
+		const modal = new ToggleBuilderModal(plugin, toggle, onClose);
+		modal.open();
+	};
+
+	const handleDelete = (idx: number) : void => {
+		toggles.splice(idx, 1);
+		plugin.saveSettings();
+		this.forceUpdate();
+		updateToggleCommands(plugin);
+	};
+
+	return (
+		<Fragment>
+			<div className="cmdr-sep-con">
+				{toggles.map((item, idx) => (
+					<div class="setting-item mod-toggle">
+						<div className="setting-item-info">
+							<div className="setting-item-name">{item.name}</div>
+						</div>
+						<div className="setting-item-control">
+							<button
+								aria-label="Edit Toggle"
+								onClick={() : void => handleBuilder(item, idx)}
+							>
+								<ObsidianIcon icon="lucide-pencil" />
+							</button>
+							<button
+								aria-label="Delete"
+								class="mod-warning"
+								onClick={async (): Promise<void> => {
+									if (
+										!plugin.settings.confirmDeletion ||
+										(await new ConfirmDeleteModal(
+											plugin
+										).didChooseRemove())
+									) {
+										handleDelete(idx);
+									}
+								}}
+							>
+								<ObsidianIcon icon="trash" />
+							</button>
+						</div>
+					</div>
+				))}
+			</div>
+			{!toggles.length && (
+				<div class="cmdr-commands-empty">
+					{/* This isn't really dangerous,
+					as the svg is inserted at build time and no other data can be passed to it */}
+					<Logo />
+					<h3>No Toggles yet!</h3>
+					<span>{t("Would you like to add one now?")}</span>
+				</div>
+			)}
+
+			{Platform.isMobile && <hr />}
+
+			<div className="cmdr-add-new-wrapper">
+				<button
+					class="mod-cta"
+					onClick={() : void  =>
+						handleBuilder({ name: "", commands: [], nextCommandIndex: 0, icon: "star" })
+					}
+				>
+					Add Toggle
+				</button>
+			</div>
+		</Fragment>
+	);
+}

--- a/src/ui/components/settingTabComponent.tsx
+++ b/src/ui/components/settingTabComponent.tsx
@@ -10,6 +10,7 @@ import AdvancedToolbarSettings from "./AdvancedToolbarSettings";
 import CommandViewer from "./commandViewerComponent";
 import { LeftRibbonHider, StatusbarHider } from "./hidingViewer";
 import MacroViewer from "./MacroViewer";
+import ToggleViewer from "./ToggleViewer";
 import { SliderComponent, ToggleComponent } from "./settingComponent";
 
 export default function settingTabComponent({
@@ -264,6 +265,15 @@ export default function settingTabComponent({
 					<MacroViewer
 						plugin={plugin}
 						macros={plugin.settings.macros}
+					/>
+				),
+			},
+			{
+				name: "Toggles",
+				tab: (
+					<ToggleViewer
+						plugin={plugin}
+						toggles={plugin.settings.toggles}
 					/>
 				),
 			},

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -156,6 +156,27 @@ export function updateMacroCommands(plugin: CommanderPlugin): void {
 	}
 }
 
+export function updateToggleCommands(plugin: CommanderPlugin): void {
+	const oldCommands = Object.keys(app.commands.commands).filter((p) =>
+		p.startsWith("cmdr:toggle-")
+	);
+	for (const command of oldCommands) {
+		//@ts-ignore
+		app.commands.removeCommand(command);
+	}
+
+	const toggles = plugin.settings.toggles;
+	for (const [idx, toggle] of Object.entries(toggles)) {
+		plugin.addCommand({
+			id: `toggle-${idx}`,
+			name: toggle.name,
+			callback: () => {
+				plugin.executeToggle(parseInt(idx));
+			},
+		});
+	}
+}
+
 export function updateStyles(settings: AdvancedToolbarSettings) {
 	const { classList: c, style: s } = document.body;
 	s.setProperty("--at-button-height", (settings.rowHeight ?? 48) + "px");


### PR DESCRIPTION
This PR adds a new element to Commander: Toggles. 

A toggle is like a macro, but defines just a name, an icon and two commands. When the command associated to the macro is executed, those two commands will be executed alternatively. This is useful to activate/deactivate something, for example.

As a more complex example: I've defined two macros, one for running a list of commands which activates different features, and other one for another list of commands which deactivates those features. In a toggle, I define those two macros. Then, running the toggle, I can switch those features on and off as a group, always in sync.

The toggle concept could be very easily morphed into a "cycle" (just removing the conditional that hides the button for adding more than two commands). That is, going through a list of commands one by one and jumping to the first one after the last one, instead of just two commands, but I think toggles are powerful enough and much more clear from the user position.

Let me know what you think.