### PR TITLE
Fix: Commander Ribbon Elements Reordering on Changes

### DIFF
--- a/src/manager/commands/leftRibbonManager.ts
+++ b/src/manager/commands/leftRibbonManager.ts
@@ -32,21 +32,21 @@ export default class LeftRibbonManager extends CommandManagerBase {
 			this.plugin.settings.leftRibbon.push(pair);
 			await this.plugin.saveSettings();
 		}
-		if (isModeActive(pair.mode)) {
-			this.plugin.addRibbonIcon(pair.icon, pair.name, () =>
-				app.commands.executeCommandById(pair.id)
-			);
+		this.plugin.addRibbonIcon(pair.icon, pair.name, () =>
+			app.commands.executeCommandById(pair.id)
+		);
+		// @ts-expect-error
+		const nativeAction = app.workspace.leftRibbon.items.find((i, index) => {
+		    const pairId = `${this.plugin.manifest.id}:${pair.name}`;
+		    return i.id === pairId;
+		});
+		if (nativeAction) {
+			nativeAction.hidden = !isModeActive(pair.mode);
 			// @ts-expect-error
-			const nativeAction = app.workspace.leftRibbon.items.find(
-				// @ts-expect-error
-				(i) => i.icon === pair.icon && i.name === i.name
-			);
-			if (nativeAction) {
-				nativeAction.buttonEl.style.color =
-					pair.color === "#000000" || pair.color === undefined
-						? "inherit"
-						: pair.color;
-			}
+			nativeAction.buttonEl.style.color =
+				pair.color === "#000000" || pair.color === undefined
+					? "inherit"
+					: pair.color;
 			this.plugin.register(() => this.removeCommand(pair, false));
 		}
 	}
@@ -60,10 +60,10 @@ export default class LeftRibbonManager extends CommandManagerBase {
 			await this.plugin.saveSettings();
 		}
 		// @ts-expect-error
-		const nativeAction = app.workspace.leftRibbon.items.find(
-			// @ts-expect-error
-			(i) => i.icon === pair.icon && i.name === i.name
-		);
+		const nativeAction = app.workspace.leftRibbon.items.find((i, index) => {
+		    const pairId = `${this.plugin.manifest.id}:${pair.name}`;
+		    return i.id === pairId;
+		});
 		if (nativeAction) {
 			nativeAction.buttonEl.remove();
 		}
@@ -78,4 +78,11 @@ export default class LeftRibbonManager extends CommandManagerBase {
 			this.addCommand(pair, false);
 		});
 	}
+
+	public update(): void {
+		this.plugin.settings.leftRibbon.forEach((pair) => {
+			this.addCommand(pair, false);
+		});
+	}
+
 }

--- a/src/ui/components/commandViewerComponent.tsx
+++ b/src/ui/components/commandViewerComponent.tsx
@@ -71,9 +71,10 @@ export default function CommandViewer({
 									handleRename={async (
 										name
 									): Promise<void> => {
-										cmd.name = name;
+										manager.removeCommand(cmd);
 										await plugin.saveSettings();
-										manager.reorder();
+										cmd.name = name;
+										manager.addCommand(cmd);
 										this.forceUpdate();
 									}}
 									handleNewIcon={async (): Promise<void> => {
@@ -84,7 +85,7 @@ export default function CommandViewer({
 										if (newIcon && newIcon !== cmd.icon) {
 											cmd.icon = newIcon;
 											await plugin.saveSettings();
-											manager.reorder();
+											manager.update();
 											this.forceUpdate();
 										}
 										dispatchEvent(
@@ -109,7 +110,7 @@ export default function CommandViewer({
 										cmd.mode =
 											mode || modes[currentIdx + 1];
 										await plugin.saveSettings();
-										manager.reorder();
+										manager.update();
 										this.forceUpdate();
 									}}
 									handleColorChange={async (
@@ -117,7 +118,7 @@ export default function CommandViewer({
 									): Promise<void> => {
 										cmd.color = color;
 										await plugin.saveSettings();
-										manager.reorder();
+										manager.update();
 									}}
 								/>
 							);
@@ -146,7 +147,6 @@ export default function CommandViewer({
 						onClick={async (): Promise<void> => {
 							const pair = await chooseNewCommand(plugin);
 							await manager.addCommand(pair);
-							manager.reorder();
 							this.forceUpdate();
 						}}
 					>


### PR DESCRIPTION
**Description:**

When adding commands via the Commander Ribbon Tab, or when changing icon, color, name, or mode, the elements are getting reordered on the ribbon. This requires the user to re-reorder the ribbon elements every time a new command is added or an already existing one is changed.

This fix allows adding, renaming, and removing commands via the Commander Ribbon tab, or changing icon, color, name, or mode, without them being reordered on the ribbon.

**Changes:**

- Implemented a new update() method in leftRibbonManager.ts that only adds commands without removing them
- Modified the handleRename method in commandViewerComponent.tsx to handle rename with only the renamed command being reordered:
    a. First, the command is being removed using the manager.removeCommand() method
    b. Then the name of the command is being changed
    c. Finally, the command is being added again using the manager.addCommand() method
- Replaced manager.reorder() calls with new method manager.update() for the following functions in src/ui/components/commandViewerComponent.tsx to handle icon/mode/color change without reordering:

    * handleNewIcon
    * handleModeChange
    * handleColorChange

- Modified addCommand() and removeCommand() method to use the id (instead of the name) for finding the native action. 
- Used nativeAction.hidden property to handle mode changes without reordering
- Removed the reorder() call in "Add command" button click handler to handle adding commands without reordering.

**Additional References:**
* https://github.com/phibr0/obsidian-commander/issues/137 for more information.