### PR TITLE
fix: additional mobile toolbar space fix introduced in 1.9.0

### DIFF
--- a/src/styles/advanced-toolbar.scss
+++ b/src/styles/advanced-toolbar.scss
@@ -16,6 +16,7 @@
 		position: sticky !important;
 		z-index: 5;
 		margin-bottom: var(--at-offset);
+		padding-bottom: 0 !important;
 	}
 
 	.mobile-toolbar-spacer {


### PR DESCRIPTION
On iOS, the fix introduced in #158, didn't actually fix it for me.

This resolves the issue for me on iOS, Obsidian v1.9.1 (207)