### PR TITLE
Fix: mobile toolbar icons not responding to clicks

### DIFF
--- a/src/ui/components/MacroViewer.tsx
+++ b/src/ui/components/MacroViewer.tsx
@@ -1,5 +1,6 @@
 import { Platform } from "obsidian";
 import { Fragment, h } from "preact";
+import { useState } from "preact/hooks";
 import t from "src/l10n";
 import CommanderPlugin from "src/main";
 import { Macro } from "src/types";
@@ -16,6 +17,8 @@ export default function MacroViewer({
 	plugin,
 	macros,
 }: MacroBuilderProps): h.JSX.Element {
+	const [, rerender] = useState(0);
+	const forceUpdate = (): void => rerender((n) => n + 1);
 	const handleBuilder = (macro: Macro, idx?: number): void => {
 		const onClose = (updatedMacro: Macro): void => {
 			macros.splice(
@@ -25,7 +28,7 @@ export default function MacroViewer({
 			);
 
 			plugin.saveSettings();
-			this.forceUpdate();
+			forceUpdate();
 			updateMacroCommands(plugin);
 			modal.close();
 		};
@@ -36,7 +39,7 @@ export default function MacroViewer({
 	const handleDelete = (idx: number): void => {
 		macros.splice(idx, 1);
 		plugin.saveSettings();
-		this.forceUpdate();
+		forceUpdate();
 		updateMacroCommands(plugin);
 	};
 

--- a/src/ui/components/commandViewerComponent.tsx
+++ b/src/ui/components/commandViewerComponent.tsx
@@ -1,4 +1,5 @@
 import { createContext, Fragment, h } from "preact";
+import { useState } from "preact/hooks";
 import CommanderPlugin from "src/main";
 import CommandComponent from "./commandComponent";
 import CommandManagerBase from "src/manager/commands/commandManager";
@@ -25,6 +26,8 @@ export default function CommandViewer({
 	children,
 	sortable = true,
 }: CommandViewerProps): h.JSX.Element {
+	const [, rerender] = useState(0);
+	const forceUpdate = (): void => rerender((n) => n + 1);
 	return (
 		<Fragment>
 			<ManagerContext.Provider value={manager}>
@@ -48,7 +51,7 @@ export default function CommandViewer({
 											).didChooseRemove())
 										) {
 											await manager.removeCommand(cmd);
-											this.forceUpdate();
+											forceUpdate();
 										}
 									}}
 									handleUp={(): void => {
@@ -58,7 +61,7 @@ export default function CommandViewer({
 											idx - 1
 										);
 										manager.reorder();
-										this.forceUpdate();
+										forceUpdate();
 									}}
 									handleDown={(): void => {
 										arrayMoveMutable(
@@ -67,7 +70,7 @@ export default function CommandViewer({
 											idx + 1
 										);
 										manager.reorder();
-										this.forceUpdate();
+										forceUpdate();
 									}}
 									handleRename={async (
 										name
@@ -75,7 +78,7 @@ export default function CommandViewer({
 										cmd.name = name;
 										await plugin.saveSettings();
 										manager.reorder();
-										this.forceUpdate();
+										forceUpdate();
 									}}
 									handleNewIcon={async (): Promise<void> => {
 										const newIcon =
@@ -86,7 +89,7 @@ export default function CommandViewer({
 											cmd.icon = newIcon;
 											await plugin.saveSettings();
 											manager.reorder();
-											this.forceUpdate();
+											forceUpdate();
 										}
 										dispatchEvent(
 											new Event("cmdr-icon-changed")
@@ -111,7 +114,7 @@ export default function CommandViewer({
 											mode || modes[currentIdx + 1];
 										await plugin.saveSettings();
 										manager.reorder();
-										this.forceUpdate();
+										forceUpdate();
 									}}
 									handleColorChange={async (
 										color?: string
@@ -148,7 +151,7 @@ export default function CommandViewer({
 							const pair = await chooseNewCommand(plugin);
 							await manager.addCommand(pair);
 							manager.reorder();
-							this.forceUpdate();
+							forceUpdate();
 						}}
 					>
 						{t("Add command")}

--- a/src/ui/components/mobileModifyComponent.tsx
+++ b/src/ui/components/mobileModifyComponent.tsx
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { useEffect } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import t from "src/l10n";
 import { ObsidianIcon } from "src/util";
 import MobileModifyModal from "../mobileModifyModal";
@@ -13,9 +13,10 @@ export default function MobileModifyComponent({
 	plugin: CommanderPlugin;
 	modal: MobileModifyModal;
 }): h.JSX.Element {
+	const [, rerender] = useState(0);
 	useEffect(() => {
 		const update = (): void => {
-			this.forceUpdate();
+			rerender((n) => n + 1);
 		};
 		addEventListener("cmdr-icon-changed", update);
 		return () => removeEventListener("cmdr-icon-changed", update);


### PR DESCRIPTION
## Summary

Toolbar icons in the plugin settings are unresponsive on mobile — tapping them does nothing. This affects all command actions: remove, reorder, rename, icon change, and mode change.

## Root Cause

`commandViewerComponent.tsx` and `mobileModifyComponent.tsx` are **functional components** that call `this.forceUpdate()`. In Preact/React functional components, `this` is `undefined`, so every call silently throws a runtime error, preventing the callback handlers from completing. On desktop this may go unnoticed since some operations still persist via other code paths, but on mobile — where all interactions flow through `MobileModifyModal` and these exact handlers — nothing works.

## Fix

Replaced `this.forceUpdate()` with a `useState` counter hook to trigger re-renders:

```tsx
const [, rerender] = useState(0);
const forceUpdate = (): void => rerender((n) => n + 1);
```

### Files changed
- `src/ui/components/commandViewerComponent.tsx` — 7 occurrences fixed
- `src/ui/components/mobileModifyComponent.tsx` — 1 occurrence fixed