### PR TITLE
fix: pin esbuild-sass-plugin to 3.3.1 to resolve CI peer dep conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"codemirror6-themes": "^0.1.2",
 				"esbuild": "^0.25.0",
 				"esbuild-plugin-alias": "^0.2.1",
-				"esbuild-sass-plugin": "^3.3.1",
+				"esbuild-sass-plugin": "3.3.1",
 				"node-fetch": "^3.3.0",
 				"npm-run-all": "^4.1.5",
 				"obsidian": "latest",
@@ -1892,18 +1892,19 @@
 			"dev": true
 		},
 		"node_modules/esbuild-sass-plugin": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.7.0.tgz",
-			"integrity": "sha512-vxNSXFx3/0ZFApKo9036ek2iRfsT+yVO99qIYqa+JaDSuJuId2/N4s1TY+xfK+5LRpAMQkfdBVUTxb/1r2bq1A==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.1.tgz",
+			"integrity": "sha512-SnO1ls+d52n6j8gRRpjexXI8MsHEaumS0IdDHaYM29Y6gakzZYMls6i9ql9+AWMSQk/eryndmUpXEgT34QrX1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"resolve": "^1.22.11",
-				"sass": "^1.97.3"
+				"resolve": "^1.22.8",
+				"safe-identifier": "^0.4.2",
+				"sass": "^1.71.1"
 			},
 			"peerDependencies": {
-				"esbuild": ">=0.27.3",
-				"sass-embedded": "^1.97.3"
+				"esbuild": ">=0.20.1",
+				"sass-embedded": "^1.71.1"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -3288,6 +3289,13 @@
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
+		},
+		"node_modules/safe-identifier": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+			"integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
@@ -5291,13 +5299,14 @@
 			"dev": true
 		},
 		"esbuild-sass-plugin": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.7.0.tgz",
-			"integrity": "sha512-vxNSXFx3/0ZFApKo9036ek2iRfsT+yVO99qIYqa+JaDSuJuId2/N4s1TY+xfK+5LRpAMQkfdBVUTxb/1r2bq1A==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.1.tgz",
+			"integrity": "sha512-SnO1ls+d52n6j8gRRpjexXI8MsHEaumS0IdDHaYM29Y6gakzZYMls6i9ql9+AWMSQk/eryndmUpXEgT34QrX1A==",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.22.11",
-				"sass": "^1.97.3"
+				"resolve": "^1.22.8",
+				"safe-identifier": "^0.4.2",
+				"sass": "^1.71.1"
 			}
 		},
 		"eslint-scope": {
@@ -6213,6 +6222,12 @@
 			"requires": {
 				"tslib": "^2.1.0"
 			}
+		},
+		"safe-identifier": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+			"integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
+			"dev": true
 		},
 		"safe-regex-test": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"codemirror6-themes": "^0.1.2",
 		"esbuild": "^0.25.0",
 		"esbuild-plugin-alias": "^0.2.1",
-		"esbuild-sass-plugin": "^3.3.1",
+		"esbuild-sass-plugin": "3.3.1",
 		"sass-embedded": "^1.71.1",
 		"node-fetch": "^3.3.0",
 		"npm-run-all": "^4.1.5",


### PR DESCRIPTION
esbuild-sass-plugin@^3.3.1 resolved to 3.7.0 in CI, which requires esbuild>=0.27.3. Our esbuild is ^0.25.0, causing ERESOLVE. Pinning to exactly 3.3.1 keeps compatibility with esbuild 0.25.x.