### PR TITLE
Follow-up: fixes made during BRAT mobile testing

### DIFF
--- a/src/ui/components/About.tsx
+++ b/src/ui/components/About.tsx
@@ -32,7 +32,7 @@ export default function About({
 			onClick={(e): void => {
 				void showConfetti(e);
 				window.setTimeout(
-					() => location.replace("https://ko-fi.com/phibr0"),
+					() => location.replace("https://buymeacoffee.com/johnny1093"),
 					Math.random() * 800 + 500
 				);
 			}}

--- a/src/ui/components/AdvancedToolbarSettings.tsx
+++ b/src/ui/components/AdvancedToolbarSettings.tsx
@@ -293,7 +293,7 @@ export default function AdvancedToolbarSettings({
 						}}
 						className="mod-cta"
 					>
-						{"Open Mobile Settings"}
+						{"Open mobile settings"}
 					</button>
 				)}
 			</div>

--- a/src/ui/components/AdvancedToolbarSettings.tsx
+++ b/src/ui/components/AdvancedToolbarSettings.tsx
@@ -289,7 +289,7 @@ export default function AdvancedToolbarSettings({
 				{Platform.isMobile && (
 					<button
 						onClick={(): void => {
-							plugin.app.setting.openTabById("mobile");
+							plugin.app.setting.openTabById("interface");
 						}}
 						className="mod-cta"
 					>


### PR DESCRIPTION
## Summary

Three small commits made during the post-merge BRAT mobile QA pass for #202, that didn't make it into that PR because I tagged/released off the local branch without pushing it first (my mistake - the PR merged a stale remote branch).

- Support Development link now points to Buy Me a Coffee (buymeacoffee.com/johnny1093), per request
- "Open Mobile Settings" button text -> sentence case, for consistency with the rest of the Advanced Toolbar tab (missed in the original batch since it's raw JSX text, not a `.setName()`/`.setDesc()` call the lint rule checks)
- Fixed that same button: `openTabById("mobile")` targeted a settings tab id that no longer exists (pre-existing bug, not introduced by #202) - now opens the Interface tab, where Configure mobile toolbar actually lives, confirmed against the correct path

## Test plan
- [x] `npm run build`, `npm test` (56/56), `npm run lint` (0 errors) green
- [x] Manually confirmed via BRAT on mobile: Buy Me a Coffee link, button text, and Interface tab navigation all working