### PR TITLE
fix: default "Show Add Command Button" to off

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8543,9 +8543,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14331,9 +14331,9 @@
 			}
 		},
 		"undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true
 		},
 		"undici-types": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { CommanderSettings } from "./types";
 
 export const DEFAULT_SETTINGS: CommanderSettings = {
 	confirmDeletion: true,
-	showAddCommand: true,
+	showAddCommand: false,
 	debug: false,
 	editorMenu: [],
 	fileMenu: [],


### PR DESCRIPTION
## Summary
- New installs default `showAddCommand` to `false` instead of `true`, so the Add Command button is hidden by default in menus.

## Test plan
- [ ] Fresh install: confirm the Add Command button is hidden by default in the settings tab and menus.
- [ ] Existing install: confirm the previously saved value (e.g. `true`) is preserved, since this only changes the default for new configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)